### PR TITLE
Fix boolean string replacement in replace_parameter

### DIFF
--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -95,7 +95,7 @@ def replace_parameter(
                     bool(replace_value) if isinstance(replace_value, int) and replace_value in [0, 1] else \
                     bool(int(replace_value)) if isinstance(replace_value, str) and replace_value in ["0", "1"] else \
                     False if isinstance(replace_value, str) and replace_value.lower() == "false" else \
-                    True if isinstance(replace_value, str) and replace_value.lower() == "True" else \
+                    True if isinstance(replace_value, str) and replace_value.lower() == "true" else \
                     replace_value
             elif isinstance(value_before_replacement, int):
                 replace_value = int(replace_value)

--- a/tests/test_replace_parameter.py
+++ b/tests/test_replace_parameter.py
@@ -1,0 +1,22 @@
+import pytest
+from onnx2tf.utils.common_functions import replace_parameter
+
+
+def test_replace_parameter_str_true_to_bool():
+    result = replace_parameter(
+        value_before_replacement=False,
+        param_target='attributes',
+        param_name='flag',
+        op_rep_params=[{'param_target': 'attributes', 'param_name': 'flag', 'values': 'True'}]
+    )
+    assert result is True
+
+
+def test_replace_parameter_str_false_to_bool():
+    result = replace_parameter(
+        value_before_replacement=True,
+        param_target='attributes',
+        param_name='flag',
+        op_rep_params=[{'param_target': 'attributes', 'param_name': 'flag', 'values': 'False'}]
+    )
+    assert result is False


### PR DESCRIPTION
## Summary
- ensure string "True" is recognized as boolean true when replacing parameters
- add tests for string-to-bool replacement handling

## Testing
- `pytest tests/test_replace_parameter.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6899b1edfa088332a5fdb228a2599606